### PR TITLE
Parsing requests

### DIFF
--- a/ConnectionHandler.cpp
+++ b/ConnectionHandler.cpp
@@ -191,7 +191,7 @@ void	ConnectionHandler::recieveDataFromClient(const unsigned int clientFd)
 		getClientPollfd(clientFd)->events = POLLOUT;
 		if (clientPTR)
 		{
-			std::unique_ptr<ResponseHandler> respHdlr(new ResponseHandler);
+			std::unique_ptr<ResponseHandler> respHdlr(new ResponseHandler); // we will need to pass the relevant config object, probably best to do in the constructor
 			respHdlr->checkRequestType(clientPTR, clientPTR->requestString);
 			if (respHdlr->getRequestType() == INVALID)
 			{

--- a/ResponseHandler.cpp
+++ b/ResponseHandler.cpp
@@ -111,16 +111,37 @@ void ResponseHandler::checkExtension(std::string filePath)
 		//there's probably a response code for this
 	}
 }
-
+void ResponseHandler::listDirectoryContents(std::string filePath)
+{
+	std::cout << "We decided we should list directory contents instead of returning a 404 error" << std::endl;
+	/* We need here:
+	return HTML file that includes:
+	Name (as link) Size and Date Modified information.
+	*/
+}
 int ResponseHandler::checkFile(clientInfo *clientPTR, std::string filePath)
 {
     std::cout << "We should now check if the file exists" << std::endl;
+	std::string defaultFilePath;
 	// this has to be fixed once we have a configuration parsing appropriately
 	if (filePath == "/")
 		filePath = "home/index.html";
 	else
 		filePath = "home" + filePath;
 	std::string content;
+	if (std::filesystem::is_directory(filePath))
+	{
+		if (filePath.back() == '/')
+			defaultFilePath = filePath + "index.html";
+		else
+			defaultFilePath = filePath + "/index.html";
+		if (std::filesystem::exists(defaultFilePath))
+			filePath = defaultFilePath;
+		else
+			std::cout <<"Call Patrik's function for directory listing" << std::endl;
+	}
+	// If we get here then we have concluded that it isn't a directory.
+	
 	std::ifstream ourFile(filePath);
 	/*We need to detect which type of error we got with the file, so we 
 	can send the appropriate response code*/
@@ -128,7 +149,9 @@ int ResponseHandler::checkFile(clientInfo *clientPTR, std::string filePath)
 	{
 		std::cerr << "Error: " << strerror(errno) << errno << std::endl;
 		if (errno == 2) //file missing
+		{
 			setResponseCode(404);
+		}
 		else if (errno == 13) //bad permissions
 			setResponseCode(403);
 		else

--- a/ResponseHandler.cpp
+++ b/ResponseHandler.cpp
@@ -143,7 +143,11 @@ int ResponseHandler::checkFile(clientInfo *clientPTR, std::string filePath)
 		if (std::filesystem::exists(defaultFilePath))
 			filePath = defaultFilePath;
 		else
+		{
 			std::cout <<"Call Patrik's function for directory listing" << std::endl;
+			buildDirListingResponse(filePath, clientPTR);
+			return 0;
+		}
 	}
 	// If we get here then we have concluded that it isn't a directory.
 	

--- a/ResponseHandler.cpp
+++ b/ResponseHandler.cpp
@@ -146,21 +146,14 @@ int ResponseHandler::checkFile(clientInfo *clientPTR, std::string filePath)
 	// we need to have separate variables for the local path vs the web path so redirects work the way they should.
 	std::string defaultFilePath;
 	std::string webFilePath;
-	// this has to be fixed once we have a configuration parsing appropriately
 
 	filePath = clientPTR->parsedRequest.filePath;
 	webFilePath = filePath;
 	std::string port = clientPTR->relatedServer->serverConfig->getPort();
 	std::cout << "Port returned: " << port << std::endl;
-	if (filePath == "/")
-	{
-		filePath = clientPTR->relatedServer->serverConfig->getRoot("/");
-		//std::cout << "Updated file path is: " << filePath << std::endl;
-		//filePath = "home/";
-	}
-	else
-		filePath = clientPTR->relatedServer->serverConfig->getRoot("/") + filePath;
-
+	filePath = clientPTR->relatedServer->serverConfig->getRoot("/") + filePath;
+	std::cout << "Updated file path is: " << filePath << std::endl;
+	
 	std::string content;
 	if (std::filesystem::is_directory(filePath))
 	{

--- a/ResponseHandler.cpp
+++ b/ResponseHandler.cpp
@@ -154,12 +154,12 @@ int ResponseHandler::checkFile(clientInfo *clientPTR, std::string filePath)
 	std::cout << "Port returned: " << port << std::endl;
 	if (filePath == "/")
 	{
-		//filePath = clientPTR->relatedServer->serverConfig->getRoot(port);
+		filePath = clientPTR->relatedServer->serverConfig->getRoot("/");
 		//std::cout << "Updated file path is: " << filePath << std::endl;
-		filePath = "home/";
+		//filePath = "home/";
 	}
 	else
-		filePath = "home" + filePath;
+		filePath = clientPTR->relatedServer->serverConfig->getRoot("/") + filePath;
 
 	std::string content;
 	if (std::filesystem::is_directory(filePath))

--- a/ResponseHandler.hpp
+++ b/ResponseHandler.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cerrno>
 #include <cstring>
+#include <filesystem>
 #include <map>
 #include "Types.hpp"
 
@@ -32,6 +33,7 @@ class ResponseHandler
 		void checkExtension(std::string filePath);
 		const enum requestTypes& getRequestType() const;
 		const unsigned int getResponseCode() const;
+		void listDirectoryContents(std::string filePath);
 		
 };
 

--- a/ResponseHandler.hpp
+++ b/ResponseHandler.hpp
@@ -35,6 +35,7 @@ class ResponseHandler
 		void checkExtension(std::string filePath);
 		const enum requestTypes& getRequestType() const;
 		unsigned int getResponseCode() const;
+		void buildRedirectResponse(std::string filePath, clientInfo *clientPTR);
 		void listDirectoryContents(std::string filePath);
 		
 };

--- a/ResponseHandler.hpp
+++ b/ResponseHandler.hpp
@@ -33,6 +33,7 @@ class ResponseHandler
 		void checkExtension(std::string filePath);
 		const enum requestTypes& getRequestType() const;
 		unsigned int getResponseCode() const;
+		void listDirectoryContents(std::string filePath);
 		
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -10,8 +10,6 @@ int main(int argc, char *argv[])
 	}
 
 	ConnectionHandler	handler;
-	//ResponseHandler		responseHandler;
-
 
 	if (handler.initServers(argv[1]) == -1)
 		return (1);

--- a/web.conf
+++ b/web.conf
@@ -22,7 +22,7 @@ server
     # Routes for different sections
     location /
     {
-        root home/; # Location of home directory
+        root home; # Location of home directory, without trailing backslashes please
         methods GET; # Allowed methods
         dir_listing off; # Disables directory listing
     }

--- a/web.conf
+++ b/web.conf
@@ -22,20 +22,20 @@ server
     # Routes for different sections
     location /
     {
-        root /home; # Location of home directory
+        root home/; # Location of home directory
         methods GET; # Allowed methods
         dir_listing off; # Disables directory listing
     }
     location /images/
     {
-        root /home/images; # Location for image files
+        root home/images; # Location for image files
         methods GET POST DELETE; # Allowed methods
         dir_listing off; # Disables directory listing
         # index images.html if we want to override the default one for this case
     }
     location /uploads/
     {
-        root /home/uploads; # Location for uploading files
+        root home/uploads; # Location for uploading files
         methods GET POST DELETE; # Allowed methods
         dir_listing off; # Disables directory listing
         # index uploads.html if we want to override the default one for this case


### PR DESCRIPTION
We will now redirect if a directory is detected without a trailing slash, similar to nginx and apache. This will resolve issue #10  

We are also now using configured webroot paths from the configuration file instead of hardcoding home/.

We can now see directory listings as well, as Patrik's function has been called appropriately.