### PR TITLE
Added files for stress testing

### DIFF
--- a/besiege_server.sh
+++ b/besiege_server.sh
@@ -1,0 +1,1 @@
+siege --delay=0.5 --file=staging-urls.txt --internet --verbose --reps=200 --concurrent=150

--- a/staging-urls.txt
+++ b/staging-urls.txt
@@ -1,0 +1,2 @@
+http://localhost:8080
+http://localhost:8080/cgi/pythonPost.html


### PR DESCRIPTION
You can now stress test the server using the included script.

Note that this only works on school computers if you have homebrew installed:
https://github.com/kube/42homebrew

And then run:
```
brew install siege
```
