### PR TITLE
Fixed crucial errors

### DIFF
--- a/ConnectionHandler.hpp
+++ b/ConnectionHandler.hpp
@@ -44,10 +44,11 @@ class ConnectionHandler
 	std::vector<pollfd>		m_pollfdVec;
 
 	int m_cgiCounter = 0;
+	int m_cgiMax = 10;
 
 	// socket functions
 	int		initServerSocket(const unsigned int portNum, ConfigurationHandler &config);
-	unsigned int convertIP(std::string IPaddress);
+	bool 	convertIP(std::string IPaddress, unsigned int &convertedIP);
 	void	closeAllSockets();
 	bool	checkForServerSocket(const int socketFd);
 
@@ -74,7 +75,7 @@ class ConnectionHandler
 	int 	splitStartLine(clientInfo *clientPTR, requestParseInfo	&parseInfo);
 	clientRequestType	checkRequestType(clientInfo *clientPTR);
 	bool	checkChunkedEnd(clientInfo *clientPTR);
-	int		getBodyLength(clientInfo *clientPTR);
+	bool	getBodyLength(clientInfo *clientPTR);
 	bool	checkForBody(clientInfo *clientPTR);
 
 	// multipart data

--- a/Structs.hpp
+++ b/Structs.hpp
@@ -33,7 +33,7 @@ struct requestParseInfo
 
 struct clientInfo
 {
-	const serverInfo	*relatedServer;
+	serverInfo			*relatedServer = nullptr;
 	requestParseInfo	parsedRequest;
 
 	ResponseHandler		*respHandler = nullptr;
@@ -44,12 +44,13 @@ struct clientInfo
 	std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
 	std::chrono::time_point<std::chrono::high_resolution_clock> curTime;
 
-	long int		reqBodyLen = -1;
+	unsigned int	reqBodyLen = 0;
 	long int		reqBodyDataRead = 0;
 	long int		bytesToWriteInCgi = -1;
 	long int		bytesReceivedFromCgi = 0;
 	bool 			bodyOK = false;
 	bool			chunkedOK = false;
+	bool			reqLenSet = false;
 
 	int		clientFd;
 	int		errorFileFd = -1;
@@ -58,7 +59,7 @@ struct clientInfo
 	int		pipeFromCgi[2] = {-1, -1};
 	int		bytesSent = 0;
 
-	int		clientTimeOutLimit = 10;
+	int		clientTimeOutLimit = 10; // Needs to be bigger in Valgrind tests
 
 	bool	stateFlags[9] = {};
 
@@ -74,10 +75,11 @@ struct clientInfo
 	int			uploadFileFd = -1;
 
 	
-	clientInfo(int clientFd) : clientFd(clientFd)
+	clientInfo(int clientFd, serverInfo *defaultServer) : clientFd(clientFd)
 	{
 		startTime = std::chrono::high_resolution_clock::now();
 		respHandler = new ResponseHandler;
+		relatedServer = defaultServer;
 	}
 
 };

--- a/requestParsing.cpp
+++ b/requestParsing.cpp
@@ -149,7 +149,8 @@ int ConnectionHandler::getRelatedServer(clientInfo *clientPTR)
 
 	}
 
-	clientPTR->relatedServer = &m_serverVec[0]; // if no appropriate server block was found, use default one.
+	// if no appropriate server block was found, we leave the relatedServer to point the default server (initialized value)
+	
 	return 0;
 }
 
@@ -213,14 +214,20 @@ int		ConnectionHandler::parseRequest(clientInfo *clientPTR)
 
 	if (it != headerMap.end())
 	{
-		int	contenLen = std::stoi(it->second);
-		if (contenLen < 0)
+		unsigned int contenLen = 0;
+		try
 		{
-			webservLog.webservLog(ERROR, "Invalid request: Content-Length is negative", true);
+			contenLen = std::stoul(it->second);
+		}
+		catch(const std::exception& e)
+		{
+			webservLog.webservLog(ERROR, e.what(), false);
+			webservLog.webservLog(ERROR, "Invalid request: Bad Content-Length value", true);
 			clientPTR->respHandler->setResponseCode(400);
 			clientPTR->respHandler->openErrorResponseFile(clientPTR);
-			return (-1);
+			return -1;
 		}
+
 		startIndex += 2; // 2 because we first move to the '\n' and then over it
 		parseInfo.rawContent = reqStr.substr(startIndex, contenLen);
 	}


### PR DESCRIPTION
- Header too long -error works now, no segfaults. This is done by initializing all clients with default server during creation, and then updating the correct server later
- std::filesystem exceptions are now caught: too long file names etc create a 400 response immidiately, and we won't have uncaught exceptions. 
- Lowered the concurrent CGI limit a bit. 
- Fixed cleanup / destruction logic so we won't end up with close(-1). 
- Added try-catch to std::stoi and fixed few int to be unsigned to fit our overall logic better
- Unit tests OK, valgrind OK, unit + valgrind OK :D