### PR TITLE
Fixed two potential risk places found during evals

### DIFF
--- a/includes/Structs.hpp
+++ b/includes/Structs.hpp
@@ -66,6 +66,7 @@ struct clientInfo
 	bool 			bodyOK = false;
 	bool			chunkedOK = false;
 	bool			reqLenSet = false;
+	bool			cgiPipeReadOK = false;
 
 	int		clientFd;
 	int		errorFileFd = -1;

--- a/srcs/ConnectionHandler.cpp
+++ b/srcs/ConnectionHandler.cpp
@@ -381,7 +381,7 @@ void	ConnectionHandler::handleClientAction(const pollfd &pollFdStuct)
 					clientPTR->pipeToCgi[1] = -1;
 				}
 
-				if (executeStatus == 0)
+				if (executeStatus == 0 && clientPTR->cgiPipeReadOK)
 				{
 					if (clientPTR->respHandler->m_cgiHandler->finishCgiResponse(clientPTR) == -1)
 					{
@@ -396,7 +396,7 @@ void	ConnectionHandler::handleClientAction(const pollfd &pollFdStuct)
 					clientPTR->pipeFromCgi[0] = -1;
 					resetClientTimeOut(clientPTR);
 				}
-				else if (executeStatus == 2 && clientPTR->pipeFromCgi[0] == pollFdStuct.fd && pollFdStuct.revents & POLLIN)
+				else if (executeStatus != -1 && clientPTR->pipeFromCgi[0] == pollFdStuct.fd && pollFdStuct.revents & POLLIN)
 				{
 					if (clientPTR->respHandler->m_cgiHandler->buildCgiResponse(clientPTR) == -1)
 					{
@@ -771,7 +771,10 @@ bool	ConnectionHandler::checkForBody(clientInfo *clientPTR)
 	if (bodySize == clientPTR->reqBodyLen)
 		return true;
 	else
+	{
+		clientPTR->reqBodyDataRead = bodySize;
 		return false;
+	}
 
 }
 


### PR DESCRIPTION
- Our function that reads CGI info from the pipe now checks when we get byteaRead = 0, which means that all the needed info has indeed been read.
- Our request receive function had a small error when only part of the request body was received during initial call to recv(), but part of it was still to be read. It's fixed now